### PR TITLE
Improving Buying Guide user flow and layout

### DIFF
--- a/_data/buying_guide.yml
+++ b/_data/buying_guide.yml
@@ -27,9 +27,9 @@
   question:
     helper_text: Telephone and cable equipment are ok.
     initial_state: hidden
-    text: Are there other electrical devices within 4 feet of the meter panel?
+    text: Is the space within 4ft clear other electrical devices?
   responses:
     - text: "Yes"
-      result: question-failure
-    - text: "No"
       result: question-success
+    - text: "No"
+      result: question-failure

--- a/_data/buying_guide.yml
+++ b/_data/buying_guide.yml
@@ -15,7 +15,7 @@
       result: question-failure
 - id: 2
   question:
-    helper_text: We need at least enough space for a credit card to lie flat aginst the meter panel surface without interference.
+    helper_text: We need at least enough space for a credit card to lie flat against the meter panel surface without interference.
     initial_state: hidden
     text: Is there space above the meter?
   responses:

--- a/_data/buying_guide.yml
+++ b/_data/buying_guide.yml
@@ -15,7 +15,7 @@
       result: question-failure
 - id: 2
   question:
-    helper_text: We need at least enough space for a credit card to lie flat on the meter panel surface above the meter without interference from a) the contoured circular flange around the meter and b)flange extending from the top of the meter panel
+    helper_text: We need at least enough space for a credit card to lie flat aginst the meter panel surface without interference.
     initial_state: hidden
     text: Is there space above the meter?
   responses:
@@ -25,9 +25,9 @@
       result: question-failure
 - id: 3
   question:
-    helper_text: Telephone and cable equipment are ok.
+    helper_text: We need 4ft of clear space. Telephone and cable equipment are ok.
     initial_state: hidden
-    text: Is the space within 4ft clear other electrical devices?
+    text: Is the space close to your meter clear of other electrical devices?
   responses:
     - text: "Yes"
       result: question-success

--- a/buying-guide.html
+++ b/buying-guide.html
@@ -68,18 +68,20 @@ layout: page
             {% for response_option in question_set.responses %}
               {% assign grid_width = 12 | divided_by: question_set.responses.size %}
 
-    					<div class="{{ grid_width }}u response">
-                {% if response_option.image_path %}
+              {% if response_option.image_path %}
+    					  <div class="{{ grid_width }}u 12u$(small) response">
                   <a href="#" class="image fit" data-question-result="{{ response_option.result }}">
                     <img src="{{ response_option.image_path }}" class="fit" /><br />
                     {{ response_option.text }}
                   </a>
-                {% else %}
+                </div>
+              {% else %}
+                <div class="{{ grid_width }}u response">
                   <a href="#" class="button" data-question-result="{{ response_option.result }}">
                     {{ response_option.text }}
                   </a>
-                {% endif %}
-    					</div>
+                </div>
+              {% endif %}
     				{% endfor %}
           </div>
   			</p>
@@ -94,7 +96,7 @@ layout: page
   		</header>
 
   		<p>
-  			Yay! Glow is compatabile with Glow. You'll be saving money and helping the environment before you know it. <a href="{{ site.share.kickstarter }}">Support us on kickstarter</a> now!
+  			Yay! Glow is compatabile with Glow. You'll be saving money and helping the environment before you know it. <br /><a class="button special fit cta" href="{{ site.share.kickstarter }}">Buy Now</a>
   		</p>
   	</section>
   </div>

--- a/buying-guide.html
+++ b/buying-guide.html
@@ -14,8 +14,8 @@ layout: page
       event.preventDefault();
     });
 
-    $("a#reset").on("click", function(event) {
-      resetSurvey();
+    $("a#start-over").on("click", function(event) {
+      startOverSurvey();
 
       event.preventDefault();
     });
@@ -46,7 +46,7 @@ layout: page
   //   console.log(target.find("a[data-question-result]"))
   // }
 
-  function resetSurvey(){
+  function startOverSurvey(){
     $('[id*=question-]').addClass("hidden"); // Hide all question-* elements
     $("#question-1").removeClass("hidden");
     scrollToId("#question-1")
@@ -113,7 +113,7 @@ layout: page
 
   <div class="row controls">
     <div class="8u -2u">
-      <a href="#" class="button special" id="reset">RESET</a>
+      <a href="#" id="start-over">Start Over</a>
     </div>
   </div>
 </div>

--- a/buying-guide.html
+++ b/buying-guide.html
@@ -9,6 +9,7 @@ layout: page
   document.addEventListener("DOMContentLoaded", function(event) {
     $("a[data-question-result]").on("click", function(event) {
       showQuestionResult($(event.target));
+      // disableSelfAndSiblings($(event.target).parents(".question"))
 
       event.preventDefault();
     });
@@ -21,65 +22,98 @@ layout: page
   });
 
   function showQuestionResult(target) {
-    var idToShow = "#" + target.data('question-result');
+    var idToShow = "#" + question_result(target);
     var element = $(idToShow);
     element.removeClass("hidden");
+
+    scrollToId(idToShow);
   }
 
+  function question_result(target) {
+    // This is to allow both link text and images to be clickable
+    var target = target.data('question-result') ? target : target.parent();
+
+    return target.data('question-result')
+  }
+
+  function scrollToId(id) {
+    $('html, body').animate({
+      scrollTop: $(id).offset().top
+    }, 1000);
+  }
+
+  // function disableSelfAndSiblings(target) {
+  //   console.log(target.find("a[data-question-result]"))
+  // }
+
   function resetSurvey(){
-    console.log("reset!");
     $('[id*=question-]').addClass("hidden"); // Hide all question-* elements
     $("#question-1").removeClass("hidden");
+    scrollToId("#question-1")
   }
 </script>
 
-{% for question_set in site.data.buying_guide %}
-	<div class="row question {{ question_set.question.initial_state }}" id="question-{{ question_set.id }}">
-		<section class="8u -2u">
-			<!-- <a href="{{ site.prefix }}{{ post.url }}" class="image full"><img src="/assets/{{ post.featured }}" alt=""></a> -->
-			<header>
-				<h2 class="question">{{ question_set.question.text }}</a></h2>
-			</header>
-			{{ question_set.question.helper_text }}
+<div class="buying-guide">
+  {% for question_set in site.data.buying_guide %}
+  	<div class="row question {{ question_set.question.initial_state }}" id="question-{{ question_set.id }}">
+  		<section class="8u -2u">
+  			<header>
+  				<h2 class="question">{{ question_set.question.text }}</a></h2>
+  			</header>
 
-			<p class="responses">
-				{% for response_option in question_set.responses %}
-					<div class="response">
-            {% if response_option.image_path %}
-              <img src="{{ response_option.image_path }}" width="300px" />
-            {% endif %}
-						<a href="#" data-question-result="{{ response_option.result }}">{{ response_option.text }}</a>
-					</div>
-				{% endfor %}
-			</p>
-		</section>
-	</div>
-{% endfor %}
+  			{{ question_set.question.helper_text }}
 
-<div class="row result hidden" id="question-success">
-	<section class="8u -2u">
-		<header>
-			<h2>Home is Compatible</a></h2>
-		</header>
+  			<p class="responses">
+          <div class="row">
+            {% for response_option in question_set.responses %}
+              {% assign grid_width = 12 | divided_by: question_set.responses.size %}
 
-		<p>
-			Yay! Your home is compatible with Glow. You'll be saving money and helping the environment before you know it. <a href="{{ site.share.kickstarter }}">Support us on kickstarter</a> now!
-		</p>
-	</section>
-</div>
+    					<div class="{{ grid_width }}u response">
+                {% if response_option.image_path %}
+                  <a href="#" class="image fit" data-question-result="{{ response_option.result }}">
+                    <img src="{{ response_option.image_path }}" class="fit" /><br />
+                    {{ response_option.text }}
+                  </a>
+                {% else %}
+                  <a href="#" class="button" data-question-result="{{ response_option.result }}">
+                    {{ response_option.text }}
+                  </a>
+                {% endif %}
+    					</div>
+    				{% endfor %}
+          </div>
+  			</p>
+  		</section>
+  	</div>
+  {% endfor %}
 
-<div class="row result hidden" id="question-failure">
-	<section class="8u -2u">
-		<header>
-			<h2>Home is not Compatible</a></h2>
-		</header>
+  <div class="row result hidden" id="question-success">
+  	<section class="8u -2u">
+  		<header>
+  			<h2>Glow is compatible!</a></h2>
+  		</header>
 
-		<p>
-			We're sorry, but your home is not compatible. Please signup below for details about when we expand abilities to support your house.
-		</p>
-	</section>
-</div>
+  		<p>
+  			Yay! Glow is compatabile with Glow. You'll be saving money and helping the environment before you know it. <a href="{{ site.share.kickstarter }}">Support us on kickstarter</a> now!
+  		</p>
+  	</section>
+  </div>
 
-<div class="row controls">
-  <a href="#" class="button" id="reset">RESET</a>
+  <div class="row result hidden" id="question-failure">
+  	<section class="8u -2u">
+  		<header>
+  			<h2>Glow is not comptabile</a></h2>
+  		</header>
+
+  		<p>
+  			We're sorry, but Glow is not currently compatible with your home. Please signup below for details about when we are able to support your home.
+  		</p>
+  	</section>
+  </div>
+
+  <div class="row controls">
+    <div class="8u -2u">
+      <a href="#" class="button special" id="reset">RESET</a>
+    </div>
+  </div>
 </div>

--- a/buying-guide.html
+++ b/buying-guide.html
@@ -39,7 +39,7 @@ layout: page
 
   function scrollToId(id) {
     $('html, body').animate({
-      scrollTop: $(id).offset().top
+      scrollTop: $(id).offset().top - ($('header').height() + 20)
     }, 1000);
   }
 
@@ -111,7 +111,7 @@ layout: page
   		</header>
 
   		<p>
-  			Yay! Glow is compatabile with Glow. You'll be saving money and helping the environment before you know it. <br /><a class="button special fit cta" href="{{ site.share.kickstarter }}">Buy Now</a>
+  			Success! Glow is compatabile with your home. You'll be saving money and helping the environment before you know it. <br /><a class="button special fit cta" href="https://www.kickstarter.com/projects/1178650747/glow-the-smart-energy-tracker-for-your-home/pledge/new">Claim Yours Now</a>
   		</p>
   	</section>
   </div>

--- a/buying-guide.html
+++ b/buying-guide.html
@@ -8,6 +8,7 @@ layout: page
 <script>
   document.addEventListener("DOMContentLoaded", function(event) {
     $("a[data-question-result]").on("click", function(event) {
+      ensureValidUIState($(event.target));
       showQuestionResult($(event.target));
       // disableSelfAndSiblings($(event.target).parents(".question"))
 
@@ -42,9 +43,23 @@ layout: page
     }, 1000);
   }
 
-  // function disableSelfAndSiblings(target) {
-  //   console.log(target.find("a[data-question-result]"))
-  // }
+  function ensureValidUIState(target) {
+    window.parentId = parseInt(target.parents(".question").data("question-index"));
+
+    $.each($("[data-question-index]"), function(index, value){
+      var id = parseInt($(value).data("question-index"));
+
+      // Don't change my current question, but keep processing
+      if (id <= window.parentId) {
+        return true
+      }
+
+      $(value).addClass("hidden")
+    })
+
+    $('#question-success').addClass("hidden");
+    $('#question-failure').addClass("hidden");
+  }
 
   function startOverSurvey(){
     $('[id*=question-]').addClass("hidden"); // Hide all question-* elements
@@ -55,7 +70,7 @@ layout: page
 
 <div class="buying-guide">
   {% for question_set in site.data.buying_guide %}
-  	<div class="row question {{ question_set.question.initial_state }}" id="question-{{ question_set.id }}">
+  	<div class="row question {{ question_set.question.initial_state }}" id="question-{{ question_set.id }}" data-question-index="{{ question_set.id }}">
   		<section class="8u -2u">
   			<header>
   				<h2 class="question">{{ question_set.question.text }}</a></h2>

--- a/css/glow.scss
+++ b/css/glow.scss
@@ -153,6 +153,21 @@ div.faq {
   }
 }
 
+div.buying-guide {
+  .question {
+    .response {
+      a {
+        border-bottom: none;
+      }
+      text-align: center;
+    }
+  }
+
+  .controls {
+    text-align: center;
+  }
+}
+
 div.press {
   width: 50%;
   margin: 0 auto;

--- a/css/glow.scss
+++ b/css/glow.scss
@@ -155,11 +155,29 @@ div.faq {
 
 div.buying-guide {
   .question {
+    header {
+      text-align: center;
+    }
+
     .response {
       a {
         border-bottom: none;
       }
       text-align: center;
+    }
+  }
+
+  .result {
+    header, p {
+      text-align: center;
+    }
+
+    p {
+      font-size: 1.25em;
+    }
+
+    .cta {
+      margin-top: 15px;
     }
   }
 


### PR DESCRIPTION
@benlachman this is taking shape.

- [ ] Get Nate to remove background tan color from meter types
- [ ] make meter icons the same size
- [ ] remove the detailed text in step two and replace with the image of the CC
- [x] make reset -> "start over" and a text link instead of button.
- [x] change step three to ask as a positive question (e.g. Is the space within 4ft clear…) so that yeses result in positive outcome.
- [x] make the go buy glow into a nice big button. And the congratulatory text larger
- [x] test on mobile (wasn't working yesterday)
- [x] disable links after a user selects a response for each question